### PR TITLE
Don't deploy demo if release push fails

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -22,9 +22,11 @@ if [ "$TRAVIS" = "true" ]; then
         new_version=`cat bower.json | grep version | awk -F\" '{print $4}'`
         git commit -m "[RELEASE] build and release $new_version"
         git tag $new_version
-        git push
-        git push --tags
-        gulp deploy-demo
+        if git push && git push --tags ; then
+            gulp deploy-demo
+        else
+            echo "Push failed probably due to concurrent trigger of release build"
+        fi
         cd $original_dir
     fi
 fi


### PR DESCRIPTION
If a second push to one of the release branches (patch, minor or major) happens before a first one had pushed a new version to RELEASE branch, the second push will not succeeded in push a new version, which is expected. But it this happens, the demo of the second push should also not be deployed.