### PR TITLE
Adding the adTagXML and adTagUrl options to the plugin

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -54,6 +54,7 @@
     "isOldIE":true,
     "isMobile": true,
     "isIPhone": true,
+    "isAndroid": true,
     /* Utils */
     "dom":true,
     "xml":true,

--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@
   >    }, 0);
   >}
   >```
-  >As you can see the requestVASTXML function above expects a node like error-first-callback that needs to be called whenever we are ready to serve the VAST XML. 
-  >If you had any error executing the request, you need to pass it as the first argument of the callback.
-  >And if there was no error pass null as the first argument and the VAST XML string as the second argument. 
+  >As you can see the requestVASTXML function above expects a node like error-first-callback that needs to be called whenever we are ready to serve the VAST XML.  
+  >If you had any error executing the request, you need to pass it as the first argument of the callback 
+  >and if there was no error pass null as the first argument and the VAST XML string as the second argument. 
 
 ### playAdAlways
   >Flag to indicate if we must play an ad whenever possible. If set to true the plugin will play an ad every time the user watches a new video or replays the actual video.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@
   >On initialization, the plugin well call the function and store the returned Media tag to request the VAST/VPAID ads.
 
 ### adTagXML
-  >You can now do the VAST xml http request on your own with our shinny new adTagXML. All you need to do is to create your custom ad plugin and pass the requestFn to the adTagXML function.
+  >You can now do the VAST xml request on your own with our shinny new adTagXML option. 
+  >
+  >All you need to do is to pass the request fn as the adTagXML option when you initialize the plugin. See below for an example
   >
   >##### Using the adTagXML option
   >```javascript
@@ -157,9 +159,9 @@
   >    }, 0);
   >}
   >```
-  >As you can see the requestVASTXML function above expects a node like error-first-callback that needs to be called whenever we have the VAST XML. 
-  >And if you had any error executing the request, you need to pass it as the first argument of the callback.
-  >It is important to note that the VAST XML must be passed as a string. 
+  >As you can see the requestVASTXML function above expects a node like error-first-callback that needs to be called whenever we are ready to serve the VAST XML. 
+  >If you had any error executing the request, you need to pass it as the first argument of the callback.
+  >And if there was no error pass null as the first argument and the VAST XML string as the second argument. 
 
 ### playAdAlways
   >Flag to indicate if we must play an ad whenever possible. If set to true the plugin will play an ad every time the user watches a new video or replays the actual video.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,36 @@
 
 ## Options
 
-### url
+### adTagUrl
+  >Use it to pass the ad media tag, it can be a string containing the Media tag url
+  >
+  >##### Hardcoded Media Tag
+  >
+  > var vastAd = player.vastClient({
+  >   adTagUrl: "http://pubads.g.doubleclick.net/gampad/ads?env=....",
+  >  ...
+  > });
+  >
+  >
+  >or a function that will return the Media tag whenever called
+  >
+  >
+  >#####  Dynamic Media Tag
+  >```javascript
+  >var vastAd = player.vastClient({
+  >adTagUrl: getAdsUrl,
+  > ...
+  >});
+  >
+  >function getAdsUrl() {
+  >      return "http://pubads.g.doubleclick.net/gampad/ads?env=....";
+  >}
+  >```
+  >On initialization, the plugin well call the function and store the returned Media tag to request the VAST/VPAID ads.
+
+
+### url (deprecated)
+  >**this option is deprecated and you should use adTagUrl instead**
   >Use it to pass the ad media tag, it can be a string containing the Media tag url
   >
   >##### Hardcoded Media Tag

--- a/README.md
+++ b/README.md
@@ -139,6 +139,27 @@
   >```
   >On initialization, the plugin well call the function and store the returned Media tag to request the VAST/VPAID ads.
 
+### adTagXML
+  >You can now do the VAST xml http request on your own with our shinny new adTagXML. All you need to do is to create your custom ad plugin and pass the requestFn to the adTagXML function.
+  >
+  >##### Using the adTagXML options
+  >```javascript
+  >var vastAd = player.vastClient({
+  >adTagXML: requestVASTXML,
+  > ...
+  >});
+  >
+  >function requestVASTXML(callback) {
+  >    //The setTimeout below is to simulate asynchrony
+  >    setTimeout(function(){
+  >      callback(null, '<VAST version="3.0"><Ad><Inline>...</Inline></Ad></VAST>');
+  >    }, 0);
+  >}
+  >```
+  >As you can see the requestVASTXML function above expects a node like error-first-callback that needs to be called whenever we have the VAST XML. 
+  >And if you had any error executing the request, you need to pass it as the first argument of the callback.
+  >It is important to note that the VAST XML must be passed as a string. 
+
 ### playAdAlways
   >Flag to indicate if we must play an ad whenever possible. If set to true the plugin will play an ad every time the user watches a new video or replays the actual video.
   >Defaults to false

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@
 
 
 ### url (deprecated)
-  >**this option is deprecated and you should use adTagUrl instead**
+  >**This option is deprecated and you should use adTagUrl instead**
+  >
   >Use it to pass the ad media tag, it can be a string containing the Media tag url
   >
   >##### Hardcoded Media Tag
@@ -142,7 +143,7 @@
 ### adTagXML
   >You can now do the VAST xml http request on your own with our shinny new adTagXML. All you need to do is to create your custom ad plugin and pass the requestFn to the adTagXML function.
   >
-  >##### Using the adTagXML options
+  >##### Using the adTagXML option
   >```javascript
   >var vastAd = player.vastClient({
   >adTagXML: requestVASTXML,

--- a/bower.json
+++ b/bower.json
@@ -33,12 +33,10 @@
     "build",
     "frontend/demo/*"
   ],
-  "dependencies": {
-    "VPAIDFLASHClient": "0.1.8",
-    "VPAIDHTML5Client": "0.1.11"
-  },
+  "dependencies": { },
   "devDependencies": {
     "video.js": "4.12.15",
-    "xhook": "1.3.0"
+    "VPAIDFLASHClient": "0.1.8",
+    "VPAIDHTML5Client": "0.1.11"
   }
 }

--- a/build/config.js
+++ b/build/config.js
@@ -33,7 +33,6 @@ module.exports = {
     ],
 
     scripts: [
-      'bower_components/xhook/dist/xhook.js',
       'bower_components/video.js/dist/video-js/video.dev.js'
     ]
   },

--- a/demo/scripts/ads-setup-plugin.js
+++ b/demo/scripts/ads-setup-plugin.js
@@ -5,13 +5,22 @@ module.exports = function molVastSetup(opts) {
   var player = this;
   var options = _.extend({}, this.options_, opts);
 
-  var vastAd = player.vastClient({
-    url: getAdsUrl,
+  var pluginSettings = {
     playAdAlways: true,
     adCancelTimeout: options.adCancelTimeout || 3000,
     adsEnabled: !!options.adsEnabled,
     vpaidFlashLoaderPath: './VPAIDFlash.swf'
-  });
+  };
+
+  if(options.adTagUrl){
+    pluginSettings.adTagUrl = options.adTagUrl;
+  }
+
+  if(options.adTagXML) {
+    pluginSettings.adTagXML = options.adTagXML;
+  }
+
+  var vastAd = player.vastClient(pluginSettings);
 
   player.on('reset', function () {
     if (player.options().plugins['ads-setup'].adsEnabled) {
@@ -28,9 +37,4 @@ module.exports = function molVastSetup(opts) {
       messages.error(error.message);
     }
   });
-
-  /**** Local functions ******/
-  function getAdsUrl() {
-    return options.adsTag;
-  }
 };

--- a/src/ads/vast/client/VASTClient.js
+++ b/src/ads/vast/client/VASTClient.js
@@ -66,8 +66,8 @@ VASTClient.prototype._getAd = function getVASTAd(adTagUrl, callback) {
 
   /*** local function ***/
   function sanityCheck(opts, cb) {
-    if (!isString(opts.adTagUrl)) {
-      return new VASTError('on VASTClient._getAd, missing video tag URL');
+    if (!opts.adTagUrl) {
+      return new VASTError('on VASTClient._getAd, missing ad tag URL');
     }
 
     if (!isFunction(cb)) {

--- a/src/ads/vast/client/VASTClient.js
+++ b/src/ads/vast/client/VASTClient.js
@@ -11,14 +11,14 @@ function VASTClient(options) {
   this.errorURLMacros = [];
 }
 
-VASTClient.prototype.getVASTResponse = function getVASTResponse(url, callback) {
+VASTClient.prototype.getVASTResponse = function getVASTResponse(adTagUrl, callback) {
   var that = this;
 
   //We reset the errorURLMacros before doing anything.
   this.errorURLMacros = [];
 
   async.waterfall([
-      this._getAd.bind(this, url),
+      this._getAd.bind(this, adTagUrl),
       buildVASTResponse
     ],
     this._sendVASTResponse(callback));

--- a/src/ads/vast/client/VASTClient.js
+++ b/src/ads/vast/client/VASTClient.js
@@ -46,10 +46,10 @@ VASTClient.prototype._sendVASTResponse = function sendVASTResponse(callback) {
   };
 };
 
-VASTClient.prototype._getAd = function getVASTAd(url, callback) {
+VASTClient.prototype._getAd = function getVASTAd(adTagUrl, callback) {
   var error;
   var that = this;
-  var options = isObject(url) && !isNull(url) ? url : {url: url};
+  var options = isObject(adTagUrl) && !isNull(adTagUrl) ? adTagUrl : {adTagUrl: adTagUrl};
   options.ads = options.ads || [];
   error = sanityCheck(options, callback);
   if (error) {
@@ -66,7 +66,7 @@ VASTClient.prototype._getAd = function getVASTAd(url, callback) {
 
   /*** local function ***/
   function sanityCheck(opts, cb) {
-    if (!isString(opts.url)) {
+    if (!isString(opts.adTagUrl)) {
       return new VASTError('on VASTClient._getAd, missing video tag URL');
     }
 
@@ -80,7 +80,7 @@ VASTClient.prototype._getAd = function getVASTAd(url, callback) {
   }
 
   function requestVASTXml(callback) {
-    that._requestVASTXml(options.url, callback);
+    that._requestVASTXml(options.adTagUrl, callback);
   }
 
   function buildAd(adXML, callback) {
@@ -120,7 +120,7 @@ VASTClient.prototype._getAd = function getVASTAd(url, callback) {
 
     function getNextAd(ad, previousAds, callback) {
       return that._getAd({
-        url: ad.wrapper.VASTAdTagURI,
+        adTagUrl: ad.wrapper.VASTAdTagURI,
         ads: previousAds.concat(ad)
       }, callback);
     }
@@ -133,7 +133,6 @@ VASTClient.prototype._requestVASTXml = function requestVASTXml(url, callback) {
       if(error) {
         return callback(new VASTError("on VASTClient.requestVastXML, HTTP request error with status '" + status + "'", 301));
       }
-      console.log('VASTXML RESPONSE', response);
 
       callback(null, response);
     }, {

--- a/src/ads/vast/client/VASTClient.js
+++ b/src/ads/vast/client/VASTClient.js
@@ -133,6 +133,8 @@ VASTClient.prototype._requestVASTXml = function requestVASTXml(url, callback) {
       if(error) {
         return callback(new VASTError("on VASTClient.requestVastXML, HTTP request error with status '" + status + "'", 301));
       }
+      console.log('VASTXML RESPONSE', response);
+
       callback(null, response);
     }, {
       withCredentials: true

--- a/src/ads/vast/client/VASTClient.js
+++ b/src/ads/vast/client/VASTClient.js
@@ -127,19 +127,29 @@ VASTClient.prototype._getAd = function getVASTAd(adTagUrl, callback) {
   }
 };
 
-VASTClient.prototype._requestVASTXml = function requestVASTXml(url, callback) {
-  try{
-    http.get(url, function (error, response, status){
-      if(error) {
-        return callback(new VASTError("on VASTClient.requestVastXML, HTTP request error with status '" + status + "'", 301));
-      }
-
-      callback(null, response);
-    }, {
-      withCredentials: true
-    });
-  }catch(e){
+VASTClient.prototype._requestVASTXml = function requestVASTXml(adTagUrl, callback) {
+  try {
+    if (isFunction(adTagUrl)) {
+      adTagUrl(requestHandler);
+    } else {
+      http.get(adTagUrl, requestHandler, {
+        withCredentials: true
+      });
+    }
+  } catch (e) {
     callback(e);
+  }
+
+  /*** Local functions ***/
+  function requestHandler(error, response, status) {
+    if (error) {
+      var errMsg = isDefined(status)?
+            "on VASTClient.requestVastXML, HTTP request error with status '" + status + "'" :
+            "on VASTClient.requestVastXML, Error getting the the VAST XML with he passed adTagXML fn";
+      return callback(new VASTError(errMsg, 301));
+    }
+
+    callback(null, response);
   }
 };
 
@@ -159,8 +169,8 @@ VASTClient.prototype._buildVastTree = function buildVastTree(xmlStr) {
     throw new VASTError('on VASTClient.buildVastTree, no Ad in VAST tree', 303);
   }
 
-  if(vastVersion && (vastVersion != 3 && vastVersion != 2)){
-    throw new VASTError('on VASTClient.buildVastTree, not supported VAST version "'+vastVersion+'"', 102);
+  if (vastVersion && (vastVersion != 3 && vastVersion != 2)) {
+    throw new VASTError('on VASTClient.buildVastTree, not supported VAST version "' + vastVersion + '"', 102);
   }
 
   return vastTree;
@@ -184,11 +194,11 @@ VASTClient.prototype._buildAd = function buildAd(adJxonTree) {
   /*** Local Functions ***/
 
   function addErrorUrlMacros(ad) {
-    if(ad.wrapper && ad.wrapper.error) {
+    if (ad.wrapper && ad.wrapper.error) {
       that.errorURLMacros.push(ad.wrapper.error);
     }
 
-    if(ad.inLine && ad.inLine.error){
+    if (ad.inLine && ad.inLine.error) {
       that.errorURLMacros.push(ad.inLine.error);
     }
   }
@@ -236,7 +246,7 @@ VASTClient.prototype._buildVASTResponse = function buildVASTResponse(adsChain) {
   function validateResponse(response) {
     var progressEvents = response.trackingEvents.progress;
 
-    if(!response.hasLinear()){
+    if (!response.hasLinear()) {
       throw new VASTError("on VASTClient._buildVASTResponse, Received an Ad type that is not supported", 200);
     }
 
@@ -245,7 +255,7 @@ VASTClient.prototype._buildVASTResponse = function buildVASTResponse(adsChain) {
     }
 
     if (progressEvents) {
-      progressEvents.forEach(function(progressEvent){
+      progressEvents.forEach(function (progressEvent) {
         if (!isNumber(progressEvent.offset)) {
           throw new VASTError("on VASTClient._buildVASTResponse, missing or wrong offset attribute on progress tracking event", 101);
         }

--- a/src/ads/videojs.vast.js
+++ b/src/ads/videojs.vast.js
@@ -36,7 +36,7 @@ vjs.plugin('vastClient', function VASTPlugin(options) {
 
   var settings = extend({}, defaultOpts, options || {});
 
-  if(isUndefined(settings.adTagUrl) && settings.url){
+  if(isUndefined(settings.adTagUrl) && isDefined(settings.url)){
     settings.adTagUrl = settings.url;
   }
 
@@ -44,7 +44,11 @@ vjs.plugin('vastClient', function VASTPlugin(options) {
     settings.adTagUrl = echoFn(settings.adTagUrl);
   }
 
-  if (!isDefined(settings.adTagUrl)) {
+  if (isDefined(settings.adTagXML) && !isFunction(settings.adTagXML)) {
+    return trackAdError(new VASTError('on VideoJS VAST plugin, the passed adTagXML option does not contain a function'));
+  }
+
+  if (!isDefined(settings.adTagUrl) && !isFunction(settings.adTagXML)) {
     return trackAdError(new VASTError('on VideoJS VAST plugin, missing adTagUrl on options object'));
   }
 
@@ -212,7 +216,7 @@ vjs.plugin('vastClient', function VASTPlugin(options) {
   }
 
   function getVastResponse(callback) {
-    vast.getVASTResponse(settings.adTagUrl(), callback);
+    vast.getVASTResponse(settings.adTagUrl ? settings.adTagUrl() : settings.adTagXML, callback);
   }
 
   function playAd(vastResponse, callback) {

--- a/src/ads/videojs.vast.js
+++ b/src/ads/videojs.vast.js
@@ -36,12 +36,16 @@ vjs.plugin('vastClient', function VASTPlugin(options) {
 
   var settings = extend({}, defaultOpts, options || {});
 
-  if (isString(settings.url)) {
-    settings.url = echoFn(settings.url);
+  if(isUndefined(settings.adTagUrl) && settings.url){
+    settings.adTagUrl = settings.url;
   }
 
-  if (!isDefined(settings.url)) {
-    return trackAdError(new VASTError('on VideoJS VAST plugin, missing url on options object'));
+  if (isString(settings.adTagUrl)) {
+    settings.adTagUrl = echoFn(settings.adTagUrl);
+  }
+
+  if (!isDefined(settings.adTagUrl)) {
+    return trackAdError(new VASTError('on VideoJS VAST plugin, missing adTagUrl on options object'));
   }
 
   playerUtils.prepareForAds(player);
@@ -208,7 +212,7 @@ vjs.plugin('vastClient', function VASTPlugin(options) {
   }
 
   function getVastResponse(callback) {
-    vast.getVASTResponse(settings.url(), callback);
+    vast.getVASTResponse(settings.adTagUrl(), callback);
   }
 
   function playAd(vastResponse, callback) {

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -86,6 +86,8 @@
     "VPAIDIntegrator":true,
     "VASTClient":true,
     "VASTTracker":true,
+    "HttpRequestError":true,
+    "HttpRequest":true,
     "VPAIDAdUnitWrapper":true,
     /* Video.js */
     "vjs":true,
@@ -105,6 +107,12 @@
     "secondArg": true,
     "thirdArg": true,
     "fourthArg": true,
-    "click": true
-    }
+    "click": true,
+    /* TEST GLOBALS */
+    "getInternetExplorerVersion": true,
+    "assertEmptyArray": true,
+    "createMouseEvent": true,
+    "isAndroid": true,
+    "_UA": true
+  }
 }

--- a/test/ads/vast/client/Creative.spec.js
+++ b/test/ads/vast/client/Creative.spec.js
@@ -1,8 +1,4 @@
 describe("Creative", function(){
-  it("must be a function", function(){
-    assert.isFunction(Creative);
-  });
-
   it("must return an instance of Creative", function(){
     assert.instanceOf(Creative(xml.toJXONTree('<Creative id="8455"></Creative>')), Creative);
   });

--- a/test/ads/vast/client/Inline.spec.js
+++ b/test/ads/vast/client/Inline.spec.js
@@ -14,10 +14,6 @@ describe("InLine", function () {
 
   });
 
-  it("must be a function", function () {
-    assert.isFunction(InLine);
-  });
-
   it("must return an instance of InLine", function () {
     assert.instanceOf(InLine(xml.toJXONTree(inlineXML)), InLine);
   });
@@ -190,6 +186,7 @@ describe("InLine", function () {
         assert.isUndefined(inline.error);
       });
 
+      /*jshint maxlen: 700 */
       it("must contain the tracking error uri if set", function () {
         inlineXML = '<InLine>' +
         '<Error><![CDATA[http://pubads.g.doubleclick.net/pagead/conversion/?ai=Bc4roEKqOVIzhJqPi7ga7y4G4CrjOsO4FAAAAEAEgyJaWHDgAWNiN_Je3AWC7rquD0AqyARN3d3cuZGFpbHltYWlsLmNvLnVrugENOHg4X3htbF92YXN0M8gBBdoBqAFodHRwOi8vd3d3LmRhaWx5bWFpbC5jby51ay90dnNob3diaXovYXJ0aWNsZS0yODU2OTEyL1BhcnR5LWdpcmwtUmloYW5uYS1sZXRzLWxvb3NlLWRhbmNlZmxvb3Itc2hvd3MtcmF1bmNoeS1tb3Zlcy1zZW1pLXNoZWVyLWdvd24tQnJpdGlzaC1GYXNoaW9uLUF3YXJkcy1hZnRlcnBhcnR5Lmh0bWyYAuiEAakCPN_bpEVluj7AAgLgAgDqAiEvNTc2NS9kbS52aWRlby9kbV92aWRlb190dnNob3diaXr4AvnRHpAD0AWYA9AFqAMB4AQBoAYj&sigh=fy3coLR3uPk&label=videoplayfailed[ERRORCODE]]]></Error>' +

--- a/test/ads/vast/client/Linear.spec.js
+++ b/test/ads/vast/client/Linear.spec.js
@@ -1,8 +1,4 @@
 describe("Linear", function(){
-  it("must be a function", function(){
-    assert.isFunction(Linear);
-  });
-
   it("must return an instance of Linear", function(){
     var linear = Linear(xml.toJXONTree('<Linear></Linear>'));
     assert.instanceOf(linear, Linear);
@@ -57,6 +53,7 @@ describe("Linear", function(){
   });
 
   describe("trackingEvents", function(){
+    /*jshint maxlen: 500 */
     it("must be filled with all the tracking events that the xml provides", function(){
       var linearXML = '<Linear>' +
         '<TrackingEvents>'+

--- a/test/ads/vast/client/MediaFile.spec.js
+++ b/test/ads/vast/client/MediaFile.spec.js
@@ -8,10 +8,6 @@ describe("MediaFile", function () {
     '</MediaFile>';
   });
 
-  it("must be a function", function () {
-    assert.isFunction(MediaFile);
-  });
-
   it("must return an instance of MediaFile", function () {
     assert.instanceOf(MediaFile(xml.toJXONTree(mediaFileXML)), MediaFile);
   });

--- a/test/ads/vast/client/TrackingEvent.spec.js
+++ b/test/ads/vast/client/TrackingEvent.spec.js
@@ -1,15 +1,12 @@
 describe("TrackingEvent", function () {
   var tracking, trackingXML;
+  /*jshint maxlen: 500 */
   beforeEach(function(){
     trackingXML = '<?xml version="1.0" encoding="UTF-8"?>' +
       '<Tracking event="firstQuartile">' +
       '<![CDATA[http://t4.liverail.com/?metric=view25&pos=0&coid=135&pid=1331&nid=1331&oid=229&olid=2291331&cid=331&tpcid=&vid=&amid=&cc=default&pp=&vi=0&vv=&sg=&tsg=&pmu=0&pau=0&psz=0&ctx=&tctx=&coty=7&adt=0&did=&buid=&scen=&mca=&mma=&mct=0&url=http%3A%2F%2Fwww.iab.net%2Fguidelines%2F508676%2Fdigitalvideo%2Fvsuite%2Fvast%2Fvast_copy%2Fvast_xml_samples&trid=54afb53ccfddf1.12174006&bidf=0.10000&bids=0.00000&bidt=1&bidh=0&bidlaf=0&sdk=0&cb=8279.195.234.241.9.0&ver=1&w=&wy=&x=&y=&xy=]]>' +
       '</Tracking>';
     tracking = TrackingEvent(xml.toJXONTree(trackingXML));
-  });
-
-  it("must be a function", function () {
-    assert.isFunction(TrackingEvent);
   });
 
   it("must return an instance of Tracking", function () {
@@ -24,6 +21,7 @@ describe("TrackingEvent", function () {
 
   describe("uri", function(){
     it("must contain the tracking uri", function(){
+      /*jshint maxlen: 700 */
       assert.equal(tracking.uri, 'http://t4.liverail.com/?metric=view25&pos=0&coid=135&pid=1331&nid=1331&oid=229&olid=2291331&cid=331&tpcid=&vid=&amid=&cc=default&pp=&vi=0&vv=&sg=&tsg=&pmu=0&pau=0&psz=0&ctx=&tctx=&coty=7&adt=0&did=&buid=&scen=&mca=&mma=&mct=0&url=http%3A%2F%2Fwww.iab.net%2Fguidelines%2F508676%2Fdigitalvideo%2Fvsuite%2Fvast%2Fvast_copy%2Fvast_xml_samples&trid=54afb53ccfddf1.12174006&bidf=0.10000&bids=0.00000&bidt=1&bidh=0&bidlaf=0&sdk=0&cb=8279.195.234.241.9.0&ver=1&w=&wy=&x=&y=&xy=');
     });
   });

--- a/test/ads/vast/client/VASTClient.spec.js
+++ b/test/ads/vast/client/VASTClient.spec.js
@@ -85,10 +85,6 @@ describe("VASTClient", function () {
         this.clock.restore();
       });
 
-      it("must be a function", function(){
-        assert.isFunction(vast.getVASTResponse);
-      });
-
       it("must pass the VASTResponse to the callback", function() {
         var response;
         vast.getVASTResponse('http://fake.url', callback);
@@ -155,10 +151,6 @@ describe("VASTClient", function () {
         vastUtil.track = origTrack;
       });
 
-      it("must be a function", function () {
-        assert.isFunction(vast._sendVASTResponse);
-      });
-
       it("must return a function", function () {
         assert.isFunction(vast._sendVASTResponse(noop));
       });
@@ -207,10 +199,6 @@ describe("VASTClient", function () {
 
       afterEach(function(){
         this.clock.restore();
-      });
-
-      it("must be a function", function () {
-        assert.isFunction(vast._getAd);
       });
 
       it("must ensure that the first argument is a URL", function () {
@@ -352,10 +340,6 @@ describe("VASTClient", function () {
         xhr.restore();
       });
 
-      it("must be a function", function () {
-        assert.isFunction(vast._requestVASTXml);
-      });
-
       it("must request the VAST response using the passed URL", function () {
         vast._requestVASTXml(url, noop);
         assert.equal(1, requests.length);
@@ -395,10 +379,6 @@ describe("VASTClient", function () {
     });
 
     describe("_buildVastTree", function () {
-      it("must be a function", function () {
-        assert.isFunction(vast._buildVastTree);
-      });
-
       it("must return the VASTTree of the passed vast XML", function () {
         var vastTree = vast._buildVastTree(vastAdXML());
         var actual = xml.toJXONTree(vastAdXML());
@@ -429,10 +409,6 @@ describe("VASTClient", function () {
     });
 
     describe("_buildAd", function(){
-      it("must be a function", function(){
-        assert.isFunction(vast._buildAd);
-      });
-
       it("must given a valid ad jxon tree return an instance of Ad", function(){
         var adTree = xml.toJXONTree(vastInLineXML('<Creatives><Creative></Creative></Creatives>')).ad;
         assert.instanceOf(vast._buildAd(adTree), Ad);
@@ -533,10 +509,6 @@ describe("VASTClient", function () {
         ads.push(wrapperAd);
         ads.push(wrapperAd2);
         ads.push(inLineAd);
-      });
-
-      it("must be a function", function(){
-        assert.isFunction(vast._buildVASTResponse);
       });
 
       it("must given an array of ads, build a vast response", function(){

--- a/test/ads/vast/client/VASTClient.spec.js
+++ b/test/ads/vast/client/VASTClient.spec.js
@@ -204,28 +204,28 @@ describe("VASTClient", function () {
       it("must ensure that the first argument is a URL", function () {
         assert.throws(function () {
           vast._getAd();
-        }, VASTError, 'VAST Error: on VASTClient._getAd, missing video tag URL');
+        }, VASTError, 'VAST Error: on VASTClient._getAd, missing ad tag URL');
 
         assert.doesNotThrow(function () {
           vast._getAd('http://foo.bar', noop);
-        }, VASTError, 'VAST Error: on VASTClient._getAd, missing video tag URL');
+        }, VASTError, 'VAST Error: on VASTClient._getAd, missing ad tag URL');
       });
 
       it("must call the callback with an explanatory error if the url is missing but the callback is set", function () {
         var callback = sinon.spy();
         vast._getAd(null, callback);
-        assertError(callback, 'on VASTClient._getAd, missing video tag URL');
+        assertError(callback, 'on VASTClient._getAd, missing ad tag URL');
         assert.isNull(secondArg(callback));
       });
 
       it("must be possible to pass an options argument as the first parameter that contains the URL", function () {
         assert.throws(function () {
           vast._getAd({});
-        }, VASTError, 'VAST Error: on VASTClient._getAd, missing video tag URL');
+        }, VASTError, 'VAST Error: on VASTClient._getAd, missing ad tag URL');
 
         assert.doesNotThrow(function () {
           vast._getAd({adTagUrl: 'http://foo.bar'}, noop);
-        }, VASTError, 'VAST Error: on VASTClient._getAd, missing video tag URL');
+        }, VASTError, 'VAST Error: on VASTClient._getAd, missing ad tag URL');
       });
 
       it("must ensure that you pass a callback function", function () {

--- a/test/ads/vast/client/VASTClient.spec.js
+++ b/test/ads/vast/client/VASTClient.spec.js
@@ -236,7 +236,7 @@ describe("VASTClient", function () {
         }, VASTError, 'VAST Error: on VASTClient._getAd, missing video tag URL');
 
         assert.doesNotThrow(function () {
-          vast._getAd({url: 'http://foo.bar'}, noop);
+          vast._getAd({adTagUrl: 'http://foo.bar'}, noop);
         }, VASTError, 'VAST Error: on VASTClient._getAd, missing video tag URL');
       });
 
@@ -260,7 +260,7 @@ describe("VASTClient", function () {
       it("must call the callback with a VASTError if we reach the WRAPPER_LIMIT on ad requests", function(){
         vast.WRAPPER_LIMIT = 2;
         vast._getAd({
-          url: 'http://fake.url',
+          adTagUrl: 'http://fake.url',
           ads: [
             new Ad(xml.toJXONTree(vastAdXML())),
             new Ad(xml.toJXONTree(vastAdXML()))

--- a/test/ads/vast/client/VASTResponse.spec.js
+++ b/test/ads/vast/client/VASTResponse.spec.js
@@ -3,10 +3,6 @@ describe("VASTResponse", function () {
     assert.deepEqual(vastResponse, new VASTResponse());
   }
 
-  it("must be a function", function () {
-    assert.isFunction(VASTResponse);
-  });
-
   it("must return an instance of itself", function () {
     assert.instanceOf(VASTResponse(), VASTResponse);
   });
@@ -88,10 +84,6 @@ describe("VASTResponse", function () {
     //HELPER FUNCTIONS
 
     describe("addAd", function () {
-      it("must be a function", function () {
-        assert.isFunction(response.addAd);
-      });
-
       it("must add the passed ad to the ads array", function () {
         var vastJTree = xml.toJXONTree('<VAST><Ad></Ad></VAST>');
         var ad = new Ad(vastJTree.ad);
@@ -140,10 +132,6 @@ describe("VASTResponse", function () {
     });
 
     describe("_addErrorTrackUrl", function () {
-      it("must be a function", function () {
-        assert.isFunction(response._addErrorTrackUrl);
-      });
-
       it("must be possible to pass the error as a string", function () {
         response._addErrorTrackUrl('http://t4.liverail.com/?metric=error&erc=[ERRORCODE]');
         assert.deepEqual(['http://t4.liverail.com/?metric=error&erc=[ERRORCODE]'], response.errorURLMacros);
@@ -168,10 +156,6 @@ describe("VASTResponse", function () {
     });
 
     describe("_addImpressions", function () {
-      it("must be a function", function () {
-        assert.isFunction(response._addImpressions);
-      });
-
       it("must not add any impression if you don't pass an array of impressions", function () {
         response._addImpressions();
         response._addImpressions({});
@@ -208,10 +192,6 @@ describe("VASTResponse", function () {
     });
 
     describe("addClickTrough", function () {
-      it("must be a function", function () {
-        assert.isFunction(response._addClickThrough);
-      });
-
       it("must not add anything if you don't pass a url str", function () {
         response._addClickThrough();
         response._addClickThrough({});
@@ -226,10 +206,6 @@ describe("VASTResponse", function () {
     });
 
     describe("_addClickTrackings", function () {
-      it("must be a function", function () {
-        assert.isFunction(response._addClickTrackings);
-      });
-
       it("must not add any clickTracking if you don't pass an array of tracking urls", function () {
         response._addClickTrackings();
         response._addClickTrackings({});
@@ -252,10 +228,6 @@ describe("VASTResponse", function () {
     });
 
     describe("_addCustomClicks", function () {
-      it("must be a function", function () {
-        assert.isFunction(response._addCustomClicks);
-      });
-
       it("must not add any customClick unless you pass an array with them inside", function () {
         response._addCustomClicks();
         response._addCustomClicks({});
@@ -285,11 +257,6 @@ describe("VASTResponse", function () {
         return new TrackingEvent(xml.toJXONTree(trackingXML));
       }
 
-
-      it("must be a function", function () {
-        assert.isFunction(response._addTrackingEvents);
-      });
-
       it("must populate the tracking event with the passed events", function(){
         var startEvent = createTrackEvent('start', 'http://track.url.com');
         response._addTrackingEvents(startEvent);
@@ -315,10 +282,6 @@ describe("VASTResponse", function () {
     });
 
     describe("_addTitle", function () {
-      it("must be a function", function () {
-        assert.isFunction(response._addTitle);
-      });
-
       it("must not set the title in the response if you don't pass a strinc with text on it", function () {
         response._addTitle('');
         response._addTitle({});
@@ -335,10 +298,6 @@ describe("VASTResponse", function () {
     });
 
     describe("_addDuration", function () {
-      it("must be a function", function () {
-        assert.isFunction(response._addDuration);
-      });
-
       it("must add the duration to the response", function () {
         response._addDuration(123);
         assert.equal(response.duration, 123);
@@ -353,10 +312,6 @@ describe("VASTResponse", function () {
     });
 
     describe("_addVideoClicks", function () {
-      it("must be a function", function () {
-        assert.isFunction(response._addVideoClicks)
-      });
-
       it("must not add anything to the response if you don't pass an instace of Inline", function () {
         response._addVideoClicks();
         response._addVideoClicks({});
@@ -405,10 +360,6 @@ describe("VASTResponse", function () {
     });
 
     describe("_addMediaFiles", function(){
-      it("must be a function", function(){
-        assert.isFunction(response._addMediaFiles);
-      });
-
       it("must not add any mediaFile unless you pass an array with them inside", function () {
         response._addMediaFiles();
         response._addMediaFiles({});
@@ -437,10 +388,6 @@ describe("VASTResponse", function () {
     });
 
     describe("_addLinear", function () {
-      it("must be a function", function () {
-        assert.isFunction(response._addLinear)
-      });
-
       it("must not add anything to the response if you don't pass an instace of Inline", function () {
         response._addLinear();
         response._addLinear({});
@@ -515,10 +462,6 @@ describe("VASTResponse", function () {
     });
 
     describe("_addInLine", function () {
-      it("must be a function", function () {
-        assert.isFunction(response._addInLine);
-      });
-
       it("must not add anything to the response if you don't pass an instance of Inline", function () {
         response._addInLine();
         response._addInLine({});
@@ -565,10 +508,6 @@ describe("VASTResponse", function () {
     });
 
     describe("_addWrapper", function () {
-      it("must be a function", function () {
-        assert.isFunction(response._addWrapper);
-      });
-
       it("must not add anything to the response if you don't pass an instance of Wrapper", function () {
         response._addWrapper();
         response._addWrapper({});

--- a/test/ads/vast/client/VASTTracker.spec.js
+++ b/test/ads/vast/client/VASTTracker.spec.js
@@ -14,10 +14,6 @@ describe("VASTTracker", function () {
     ASSET_URI = 'http://ASSET_URI';
   });
 
-  it("must be a function", function () {
-    assert.isFunction(VASTTracker);
-  });
-
   it("must return an instance of itself", function () {
     assert.instanceOf(VASTTracker(ASSET_URI, response), VASTTracker);
   });
@@ -83,10 +79,6 @@ describe("VASTTracker", function () {
         tracker = new VASTTracker(ASSET_URI, response);
       });
 
-      it("must be a function", function(){
-        assert.isFunction(tracker.trackURLs);
-      });
-
       it("must add ASSETURI and CONTENTPLAYHEAD to the tracking variables", function(){
         tracker.trackURLs(['http://sample.track.url']);
         assertVASTTrackRequest(['http://sample.track.url'], {
@@ -123,10 +115,6 @@ describe("VASTTracker", function () {
           createTrackEvent('firstQuartile', 'http://firstQuartile.trackEvent.url')
         ]);
         tracker = new VASTTracker(ASSET_URI, response);
-      });
-
-      it("must be a function", function () {
-        assert.isFunction(tracker.trackEvent);
       });
 
       it("must track the passed event", function () {
@@ -381,10 +369,6 @@ describe("VASTTracker", function () {
         tracker = new VASTTracker(ASSET_URI, response);
       });
 
-      it("must be a function", function(){
-        assert.isFunction(tracker.trackErrorWithCode);
-      });
-
       it("must track the passed error code", function(){
         tracker.trackErrorWithCode(101);
         assertVASTTrackRequest(['http://error.track.url'], {
@@ -411,10 +395,6 @@ describe("VASTTracker", function () {
         tracker = new VASTTracker(ASSET_URI, response);
       });
 
-      it("must be a function", function(){
-        assert.isFunction(tracker.trackImpressions);
-      });
-
       it("must track the impressionURLs", function(){
         tracker.trackImpressions();
         assertVASTTrackRequest(['http://impressions.track.url'], {
@@ -434,10 +414,6 @@ describe("VASTTracker", function () {
         tracker = new VASTTracker(ASSET_URI, response);
       });
 
-      it("must be a function", function(){
-        assert.isFunction(tracker.trackCreativeView);
-      });
-
       it("must track the creativeViewURLs when called with trackCreativeView", function(){
         tracker.trackCreativeView();
         assertVASTTrackRequest(['http://creativeView.trackEvent.url'], {ASSETURI: ASSET_URI, CONTENTPLAYHEAD: "00:00:00.000"});
@@ -455,10 +431,6 @@ describe("VASTTracker", function () {
       beforeEach(function () {
         response._addClickTrackings(['http://click.track.url']);
         tracker = new VASTTracker(ASSET_URI, response);
-      });
-
-      it("must be a function", function(){
-        assert.isFunction(tracker.trackClick);
       });
 
       it("must track the clickTracking URLS", function(){

--- a/test/ads/vast/client/VideoClicks.spec.js
+++ b/test/ads/vast/client/VideoClicks.spec.js
@@ -8,10 +8,6 @@ describe("VideoClicks", function () {
     videoClicks = new VideoClicks(xml.toJXONTree(videoClicksXML));
   });
 
-  it("must be a function", function () {
-    assert.isFunction(VideoClicks);
-  });
-
   it("must return an instance of VideoClicks", function () {
     assert.instanceOf(VideoClicks(videoClicksXML), VideoClicks);
   });

--- a/test/ads/vast/client/Wrapper.spec.js
+++ b/test/ads/vast/client/Wrapper.spec.js
@@ -1,8 +1,4 @@
 describe("Wrapper", function () {
-  it("must be a function", function () {
-    assert.isFunction(Wrapper);
-  });
-
   it("must return an instance of Wrapper", function () {
     assert.instanceOf(Wrapper(xml.toJXONTree('<Wrapper></Wrapper>')), Wrapper);
   });

--- a/test/ads/vast/client/vastUtil.spec.js
+++ b/test/ads/vast/client/vastUtil.spec.js
@@ -10,10 +10,6 @@ describe("vastUtil", function () {
       _parseURLMacro = vastUtil._parseURLMacro;
     });
 
-    it("must be a function", function () {
-      assert.isFunction(vastUtil._parseURLMacro);
-    });
-
     it("must parse the passed macro using the passed variables", function () {
       assert.equal('http://foo.bar/BLA', _parseURLMacro('http://foo.bar/[CODE]', {CODE: 'BLA'}));
       assert.equal('http://foo.bar/BLA/123', _parseURLMacro('http://foo.bar/[CODE]/[END]', {CODE: 'BLA', END: 123}));
@@ -25,10 +21,6 @@ describe("vastUtil", function () {
 
     beforeEach(function(){
       parseURLMacro = vastUtil.parseURLMacro;
-    });
-
-    it("must be a function", function(){
-      assert.isFunction(vastUtil.parseURLMacro);
     });
 
     it("must parse the passed macro and return the parsed url", function () {
@@ -82,10 +74,6 @@ describe("vastUtil", function () {
       track = vastUtil.track;
     });
 
-    it("must be a function", function () {
-      assert.isFunction(track);
-    });
-
     it("must return an array with the created track images", function () {
       var macros = [
         'http://foo.bar/[CODE]',
@@ -106,10 +94,6 @@ describe("vastUtil", function () {
 
     beforeEach(function () {
       parseDuration = vastUtil.parseDuration;
-    });
-
-    it("must be a function", function () {
-      assert.isFunction(vastUtil.parseDuration);
     });
 
     it("must return null if the duration is not an string with the format HH:MM:SS[.mmm]", function () {
@@ -133,10 +117,6 @@ describe("vastUtil", function () {
 
     beforeEach(function(){
       parseImpressions = vastUtil.parseImpressions;
-    });
-
-    it("must be a function", function(){
-      assert.isFunction(vastUtil.parseImpressions);
     });
 
     it("must return an empty array if you pass no impressions", function () {
@@ -187,10 +167,6 @@ describe("vastUtil", function () {
       parseCreatives = vastUtil.parseCreatives;
     });
 
-    it("must be a function", function(){
-      assert.isFunction(vastUtil.parseCreatives);
-    });
-
     it("must return an empty array if you pass no creativesJTree", function () {
       assertEmptyArray(parseCreatives());
     });
@@ -219,10 +195,6 @@ describe("vastUtil", function () {
   });
 
   describe("formatProgress", function(){
-    it("must be a function", function(){
-      assert.isFunction(vastUtil.formatProgress);
-    });
-
     it("must return the formatted progress", function(){
       assert.equal(vastUtil.formatProgress(12345000), "03:25:45.000");
       assert.equal(vastUtil.formatProgress(123000), "00:02:03.000");
@@ -235,10 +207,6 @@ describe("vastUtil", function () {
 
     beforeEach(function(){
       parseOffset = vastUtil.parseOffset;
-    });
-
-    it("must be a function", function(){
-      assert.isFunction(vastUtil.parseOffset);
     });
 
     it("must return the passed offset string in ms", function(){

--- a/test/ads/vast/videojs.vast.spec.js
+++ b/test/ads/vast/videojs.vast.spec.js
@@ -65,7 +65,7 @@ describe("videojs.vast plugin", function () {
     player.on('vast.adError', spy);
     player.vastClient();
     sinon.assert.calledOnce(spy);
-    assertError(spy, 'on VideoJS VAST plugin, missing url on options object');
+    assertError(spy, 'on VideoJS VAST plugin, missing adTagUrl on options object');
   });
 
   it("must not trigger 'vast.adError' if the ads url is passed as part of the options", function () {

--- a/test/ads/vast/videojs.vast.spec.js
+++ b/test/ads/vast/videojs.vast.spec.js
@@ -68,19 +68,37 @@ describe("videojs.vast plugin", function () {
     assertError(spy, 'on VideoJS VAST plugin, missing adTagUrl on options object');
   });
 
-  it("must not trigger 'vast.adError' if the ads url is passed as part of the options", function () {
+  it("must not trigger 'vast.adError' if the adTagUrl is passed as part of the options", function () {
     var vastErrorSpy = sinon.spy();
     var player = videojs(document.createElement('video'), {});
     player.on('vast.adError', vastErrorSpy);
-    player.vastClient({url: 'http://fake.ad.url'});
+    player.vastClient({adTagUrl: 'http://fake.ad.url'});
     sinon.assert.notCalled(vastErrorSpy);
+  });
+
+  it("must not trigger 'vast.adError' if the adTagXML is defined as part of the options", function(){
+    var vastErrorSpy = sinon.spy();
+    var player = videojs(document.createElement('video'), {});
+    player.on('vast.adError', vastErrorSpy);
+    player.vastClient({adTagXML: noop});
+    sinon.assert.notCalled(vastErrorSpy);
+  });
+
+  it("must trigger a 'vast.adError' if the passed adTagXML is not a function", function(){
+    var spy = sinon.spy();
+    var player = videojs(document.createElement('video'), {});
+
+    player.on('vast.adError', spy);
+    player.vastClient({adTagXML: 'NOT A FUNCTION'});
+    sinon.assert.calledOnce(spy);
+    assertError(spy, 'on VideoJS VAST plugin, the passed adTagXML option does not contain a function');
   });
 
   it("must cancel the ads on 'vast.reset' evt", function(){
     var spy = sinon.spy();
     var player = videojs(document.createElement('video'), {});
     player.on('vast.adsCancel', spy);
-    player.vastClient({url: 'http://fake.ad.url'});
+    player.vastClient({adTagUrl: 'http://fake.ad.url'});
     player.trigger('vast.reset');
     sinon.assert.calledOnce(spy);
   });
@@ -100,7 +118,7 @@ describe("videojs.vast plugin", function () {
 
     it("set to true, must reset plugin 'vast.firstPlay' event", function () {
       player.vastClient({
-        url: echoFn('/fake.ad.url'),
+        adTagUrl: echoFn('/fake.ad.url'),
         playAdAlways: true
       });
       player.on('vast.reset', resetSpy);
@@ -112,7 +130,7 @@ describe("videojs.vast plugin", function () {
 
     it("set to false, must try not play a new ad every time the user replays the ad", function () {
       player.vastClient({
-        url: echoFn('/fake.ad.url'),
+        adTagUrl: echoFn('/fake.ad.url'),
         playAdAlways: false
       });
 
@@ -129,7 +147,7 @@ describe("videojs.vast plugin", function () {
 
     beforeEach(function () {
       player = videojs(document.createElement('video'), {});
-      vastAd = player.vastClient({url: 'http://fake.ad.url'});
+      vastAd = player.vastClient({adTagUrl: 'http://fake.ad.url'});
     });
 
     it("must be equal to the object returned by the plugin", function(){
@@ -166,7 +184,7 @@ describe("videojs.vast plugin", function () {
       clock = sinon.useFakeTimers();
       player = videojs(document.createElement('video'), {});
       player.vastClient({
-        url: echoFn('/fake.ad.url'),
+        adTagUrl: echoFn('/fake.ad.url'),
         playAdAlways: true
       });
     });
@@ -240,7 +258,7 @@ describe("videojs.vast plugin", function () {
       describe("loading spinner", function(){
         beforeEach(function(){
           player = videojs(document.createElement('video'), {});
-          player.vastClient({url: echoFn('/fake.ad.url')});
+          player.vastClient({adTagUrl: echoFn('/fake.ad.url')});
         });
 
         it("must be added while we retrieve the ad", function(){
@@ -270,7 +288,7 @@ describe("videojs.vast plugin", function () {
 
       it("must pause the video if it is not paused", function(){
         player = videojs(document.createElement('video'), {});
-        player.vastClient({url: echoFn('/fake.ad.url'), adCancelTimeout:5000});
+        player.vastClient({adTagUrl: echoFn('/fake.ad.url'), adCancelTimeout:5000});
         sinon.spy(player, 'pause');
         player.trigger('vast.firstPlay');
         clock.tick(1);
@@ -279,7 +297,7 @@ describe("videojs.vast plugin", function () {
 
       it("must cancel the ads if there it takes too much time (adCancelTimeout) to start the ad", function(){
         player = videojs(document.createElement('video'), {});
-        player.vastClient({url: echoFn('/fake.ad.url'), adCancelTimeout: 3000});
+        player.vastClient({adTagUrl: echoFn('/fake.ad.url'), adCancelTimeout: 3000});
 
         assertTriggersTrackError(function () {
           player.trigger('vast.firstPlay');
@@ -290,7 +308,7 @@ describe("videojs.vast plugin", function () {
       it("must not cancel the ad if the ad starts before the timeout", function(){
         var adsCancelSpy = sinon.spy();
         player = videojs(document.createElement('video'), {});
-        player.vastClient({url: echoFn('/fake.ad.url'), adCancelTimeout: 3000});
+        player.vastClient({adTagUrl: echoFn('/fake.ad.url'), adCancelTimeout: 3000});
         player.on('vast.adsCancel', adsCancelSpy);
         player.trigger('vast.firstPlay');
         clock.tick(1);
@@ -451,7 +469,7 @@ describe("videojs.vast plugin", function () {
       sinon.stub(vastUtil, 'track').returns(null);
       sinon.spy(VASTIntegrator.prototype, 'playAd');
       player = videojs(document.createElement('video'), {});
-      player.vastClient({url: echoFn('/fake.ad.url')});
+      player.vastClient({adTagUrl: echoFn('/fake.ad.url')});
       getVASTResponse = sinon.spy(VASTClient.prototype, 'getVASTResponse');
       player.trigger('vast.firstPlay');
       this.clock.tick(1);
@@ -469,6 +487,14 @@ describe("videojs.vast plugin", function () {
     it("must request the vastResponse", function () {
       sinon.assert.calledOnce(getVASTResponse);
       sinon.assert.calledWith(getVASTResponse, '/fake.ad.url');
+    });
+
+    it("must request the vastResponse using the adTagXML function if provided", function(){
+      player = videojs(document.createElement('video'), {});
+      player.vastClient({adTagXML: noop});
+      player.trigger('vast.firstPlay');
+      this.clock.tick(1);
+      sinon.assert.calledWith(getVASTResponse, noop);
     });
 
     it("must track the vast response if there was an error retrieving the vast response", function () {
@@ -758,7 +784,7 @@ describe("videojs.vast plugin", function () {
       sinon.stub(player, 'currentTime').returns(2000);
       player.on('vast.adError', errorSpy);
 
-      player.vastClient({url: 'http://fake.ad.url', iosPrerollCancelTimeout: 1000});
+      player.vastClient({adTagUrl: 'http://fake.ad.url', iosPrerollCancelTimeout: 1000});
       player.trigger('vast.firstPlay');
       this.clock.tick(1);
       sinon.assert.calledOnce(errorSpy);
@@ -770,7 +796,7 @@ describe("videojs.vast plugin", function () {
       var errorSpy = sinon.spy();
       sinon.stub(player, 'currentTime').returns(500);
       player.on('vast.adError', errorSpy);
-      player.vastClient({url: 'http://fake.ad.url', iosPrerollCancelTimeout: 1000});
+      player.vastClient({adTagUrl: 'http://fake.ad.url', iosPrerollCancelTimeout: 1000});
       player.trigger('vast.firstPlay');
       this.clock.tick(1);
       sinon.assert.notCalled(errorSpy);

--- a/test/ads/vpaid/VPAIDAdUnitWrapper.spec.js
+++ b/test/ads/vpaid/VPAIDAdUnitWrapper.spec.js
@@ -18,15 +18,7 @@ describe("VPAIDAdUnitWrapper", function(){
     };
   });
 
-  it("must be a function", function(){
-    assert.isFunction(VPAIDAdUnitWrapper);
-  });
-
   describe("checkVPAIDInterface", function(){
-    it("must be a function", function(){
-      assert.isFunction(VPAIDAdUnitWrapper.checkVPAIDInterface);
-    });
-
     it("must return false if you pass an obj that does not fully implements the VPAID interface", function(){
       assert.isFalse(VPAIDAdUnitWrapper.checkVPAIDInterface());
       assert.isFalse(VPAIDAdUnitWrapper.checkVPAIDInterface(null));
@@ -77,15 +69,15 @@ describe("VPAIDAdUnitWrapper", function(){
     it("must throw a VASTError if the passed VPAIDAdUnit does not fully implement the VPAID api", function(){
      [null, undefined, noop, 'foo', {}, []].forEach(function(invalidAdUnit) {
        assert.throws(function () {
-         new VPAIDAdUnitWrapper(invalidAdUnit);
+         var adUnitWrapper = new VPAIDAdUnitWrapper(invalidAdUnit);
        }, VASTError, 'on VPAIDAdUnitWrapper, the passed VPAID adUnit does not fully implement the VPAID interface');
      });
     });
 
     it("must complain if you pass an options that is not a hash", function(){
       assert.throws(function() {
-        new VPAIDAdUnitWrapper(vpaidAdUnit, 'foo');
-      }, VASTError, "on VPAIDAdUnitWrapper, expected options hash  but got 'foo'")
+        var adUnitWrapper = new VPAIDAdUnitWrapper(vpaidAdUnit, 'foo');
+      }, VASTError, "on VPAIDAdUnitWrapper, expected options hash  but got 'foo'");
     });
 
     it("must publish the VPAIDAdUnit in '_adUnit'", function(){
@@ -110,10 +102,6 @@ describe("VPAIDAdUnitWrapper", function(){
         this.clock.restore();
       });
 
-      it("must be a function", function(){
-        assert.isFunction(wrapper.adUnitAsyncCall);
-      });
-
       it("must complain if the method is not part of the adUnit", function(){
         assert.throws(function () {
           wrapper.adUnitAsyncCall('foo', noop);
@@ -129,7 +117,7 @@ describe("VPAIDAdUnitWrapper", function(){
       it("must call the adUnit method", function(){
         sinon.spy(vpaidAdUnit, 'initAd');
         wrapper.adUnitAsyncCall('initAd', noop);
-        sinon.assert.calledOnce(vpaidAdUnit.initAd)
+        sinon.assert.calledOnce(vpaidAdUnit.initAd);
       });
 
       it("must call the callback whenever the adUnit response comes back", function(){
@@ -172,10 +160,6 @@ describe("VPAIDAdUnitWrapper", function(){
     });
 
     describe("on", function(){
-      it("must be a function", function(){
-        assert.isFunction(wrapper.on);
-      });
-
       it("must call the subscribe method of the inner adunit", function(){
         vpaidAdUnit.on = undefined;
         vpaidAdUnit.addEventListener = undefined;
@@ -205,10 +189,6 @@ describe("VPAIDAdUnitWrapper", function(){
     });
 
     describe("off", function(){
-      it("must be a function", function(){
-        assert.isFunction(wrapper.off);
-      });
-
       it("must call the unsubscribe method of the inner adunit", function(){
         vpaidAdUnit.off = undefined;
         vpaidAdUnit.removeEventListener = undefined;
@@ -238,10 +218,6 @@ describe("VPAIDAdUnitWrapper", function(){
     });
 
     describe("waitForEvent", function(){
-      it("must be a function", function(){
-        assert.isFunction(wrapper.waitForEvent);
-      });
-
       it("must complain if you don't pass an evtName", function(){
         assert.throws(function () {
           wrapper.waitForEvent();
@@ -296,7 +272,7 @@ describe("VPAIDAdUnitWrapper", function(){
           error = firstArg(callback);
 
           assert.instanceOf(error, VASTError);
-          assert.equal(error.message, "VAST Error: on VPAIDAdUnitWrapper.waitForEvent, timeout while waiting for event 'adInit'")
+          assert.equal(error.message, "VAST Error: on VPAIDAdUnitWrapper.waitForEvent, timeout while waiting for event 'adInit'");
         });
 
         it("must not call the callback once the event response comes", function(){

--- a/test/ads/vpaid/VPAIDFlashTech.spec.js
+++ b/test/ads/vpaid/VPAIDFlashTech.spec.js
@@ -4,10 +4,6 @@ describe("VPAIDFlashTech", function () {
   });
 
   describe("supports", function () {
-    it("must be a function", function () {
-      assert.isFunction(VPAIDFlashTech.supports);
-    });
-
     describe('must handle flash support', function() {
       var FLASH_STRING = 'application/x-shockwave-flash';
       var originalFlash;
@@ -30,7 +26,7 @@ describe("VPAIDFlashTech", function () {
       });
 
       it("must return false when you pass 'application/x-shockwave-flash' if the browser doesn't support it", function() {
-        sinon.stub(VPAIDFLASHClient, 'isSupported', function () {return false});
+        sinon.stub(VPAIDFLASHClient, 'isSupported', function () {return false;});
         assert.isFalse(VPAIDFlashTech.supports(FLASH_STRING));
       });
 
@@ -47,8 +43,8 @@ describe("VPAIDFlashTech", function () {
   it("must complain if you don't pass a valid media file", function(){
     [undefined, null, {}, []].forEach(function (invalidMediaFile) {
       assert.throws(function() {
-        new VPAIDFlashTech(invalidMediaFile);
-      }, VASTError, 'VAST Error: on VPAIDFlashTech, invalid MediaFile')
+        var tech = new VPAIDFlashTech(invalidMediaFile);
+      }, VASTError, 'VAST Error: on VPAIDFlashTech, invalid MediaFile');
     });
   });
 

--- a/test/ads/vpaid/VPAIDIntegrator.spec.js
+++ b/test/ads/vpaid/VPAIDIntegrator.spec.js
@@ -370,10 +370,6 @@ describe("VPAIDIntegrator", function () {
 
       });
 
-      it("must be a function", function () {
-        assert.isFunction(vpaidIntegrator._handshake);
-      });
-
       it("must pass an error to the callback if the VPAID version is smaller than 1.0", function () {
         vpaidIntegrator._handshake(adUnitWrapper, response, next);
         sinon.assert.calledWith(vpaidAdUnit.handshakeVersion, '2.0');
@@ -431,10 +427,6 @@ describe("VPAIDIntegrator", function () {
 
       afterEach(function(){
         dom.getDimension.restore();
-      });
-
-      it("must be a function", function () {
-        assert.isFunction(vpaidIntegrator._initAd);
       });
 
       it("must call pass the with, height, viewmode, desired bitrate, and creativeData to the adUnit's initAd", function () {

--- a/test/utils/async.spec.js
+++ b/test/utils/async.spec.js
@@ -12,10 +12,6 @@ describe("async", function () {
       this.clock.restore();
     });
 
-    it("must be a function", function () {
-      assert.isFunction(async.setImmediate);
-    });
-
     it("must call the passed function asynchronously", function () {
       var spy = sinon.spy();
       async.setImmediate(spy);
@@ -32,10 +28,6 @@ describe("async", function () {
       task1 = sinon.spy();
       task2 = sinon.spy();
       task3 = sinon.spy();
-    });
-
-    it("must be a function", function () {
-      assert.isFunction(async.iterator);
     });
 
     it("must return an iterator that iterates over the array of tasks", function () {
@@ -59,10 +51,6 @@ describe("async", function () {
   });
 
   describe("waterfall", function () {
-    it("must be a function", function () {
-      assert.isFunction(async.waterfall);
-    });
-
     it("must pass an error to the callback if you don't pass an array for tasks", function () {
       var callback = sinon.spy();
       async.waterfall(null, callback);
@@ -152,17 +140,13 @@ describe("async", function () {
   });
 
   describe("when", function () {
-    it("must be a function", function () {
-      assert.isFunction(async.when);
-    });
-
     it("must return a function", function () {
       assert.isFunction(async.when(false, noop));
     });
 
     it("must throw an exception if the second argument is not a callback", function () {
       assert.throws(function () {
-        async.when()
+        async.when();
       }, Error, 'async.when error: missing callback argument');
     });
 

--- a/test/utils/dom.spec.js
+++ b/test/utils/dom.spec.js
@@ -361,10 +361,6 @@ describe("dom", function () {
   });
 
   describe("remove", function () {
-    it("must be a function", function () {
-      assert.isFunction(dom.remove)
-    });
-
     it("must remove the passed node from the document", function () {
       var node = document.createElement('div');
       node.id = 'testElem';
@@ -376,10 +372,6 @@ describe("dom", function () {
   });
 
   describe("isDomElement", function () {
-    it("must be a function", function () {
-      assert.isFunction(dom.isDomElement);
-    });
-
     it("must return true if you pass a DOM element and false otherwise", function () {
       assert.isTrue(dom.isDomElement(document.createElement('div')));
       assert.isFalse(dom.isDomElement(document.createTextNode('foo text')));
@@ -393,10 +385,6 @@ describe("dom", function () {
   });
 
   describe("click", function () {
-    it("must be a function", function () {
-      assert.isFunction(dom.click);
-    });
-
     it("must execute the handler whenever the user clicks on the element", function () {
       var anchor = createEl('a');
       var spy = sinon.spy();
@@ -407,10 +395,6 @@ describe("dom", function () {
   });
 
   describe("once", function () {
-    it("must be a function", function () {
-      assert.isFunction(dom.once);
-    });
-
     it("must register a listener to the specified event type", function () {
       var el = createEl('div');
       var spy = sinon.spy();

--- a/test/utils/http/http.spec.js
+++ b/test/utils/http/http.spec.js
@@ -1,11 +1,7 @@
 describe("HttpRequest", function () {
-  it("must be a function", function () {
-    assert.isFunction(HttpRequest);
-  });
-
   it("must throw an exception if you don't pass a xhrFactory function", function () {
     assert.throws(function () {
-      new HttpRequest();
+      var http = new HttpRequest();
     }, HttpRequestError, 'HttpRequest Error: Missing XMLHttpRequest factory method');
   });
 
@@ -32,10 +28,6 @@ describe("HttpRequest", function () {
     });
 
     describe("run", function () {
-      it("must be a function", function () {
-        assert.isFunction($http.run);
-      });
-
       it("must throw an exception if you don't pass a valid url", function () {
         assert.throws(function () {
           $http.run('GET');
@@ -229,10 +221,6 @@ describe("HttpRequest", function () {
     });
 
     describe("get", function () {
-      it("must be a function", function () {
-        assert.isFunction($http.get);
-      });
-
       it("must do a GET request", function () {
         var run = sinon.spy($http, 'run');
         var options = {};

--- a/test/utils/utilityFunctions.spec.js
+++ b/test/utils/utilityFunctions.spec.js
@@ -162,10 +162,6 @@ describe("isString", function () {
 });
 
 describe("isEmptyString", function(){
-  it("must be a function", function(){
-    assert.isFunction(isEmptyString);
-  });
-
   it("must return true if you pass an empty string", function(){
     assert.isTrue(isEmptyString(''));
   });
@@ -384,7 +380,7 @@ describe("extend", function () {
 
   it("must return the passed object if that is the only thing you pass", function () {
     var o = {};
-    assert.strictEqual(extend(o), o)
+    assert.strictEqual(extend(o), o);
   });
 
   //Regression test
@@ -511,7 +507,7 @@ describe("transform", function(){
       {
         name: 'ITEM2'
       }
-    ]
+    ];
   });
   
   it("must call the transform function with each item of the array and its index", function(){
@@ -529,7 +525,7 @@ describe("transform", function(){
       return index;
     });
 
-    assert.deepEqual(newArray, [0, 1])
+    assert.deepEqual(newArray, [0, 1]);
   });
 
   it("must ignore undefined transformed items", function(){
@@ -537,15 +533,11 @@ describe("transform", function(){
       return undefined;
     });
 
-    assert.deepEqual(newArray, [])
+    assert.deepEqual(newArray, []);
   });
 });
 
 describe("toFixedDigits", function(){
-  it("must be a function", function(){
-    assert.isFunction(toFixedDigits)
-  });
-
   it("must return a string that contains the numbers with the fixed number of digits", function(){
     assert.equal(toFixedDigits(3, 2), '03');
     assert.equal(toFixedDigits(11, 2), '11');
@@ -631,7 +623,7 @@ describe("treeSearch", function(){
   var isName = function (name){
     return function (obj){
       return obj.name == name;
-    }
+    };
   };
 
   it("must traverse a tree", function(){
@@ -646,10 +638,6 @@ describe("treeSearch", function(){
 });
 
 describe("echoFn", function(){
-  it("must be a function", function(){
-    assert.isFunction(echoFn);
-  });
-
   it("must return a function", function(){
     assert.isFunction(echoFn());
   });
@@ -666,10 +654,6 @@ describe("echoFn", function(){
 });
 
 describe("isISO8601", function(){
-  it("must be a function", function(){
-    assert.isFunction(isISO8601);
-  });
-
   it("must return false for YYYY date format (year)", function(){
     assert.isTrue(isISO8601("1983"));
   });
@@ -728,6 +712,7 @@ describe("isISO8601", function(){
   });
 });
 
+/*jshint maxlen: 500 */
 describe("getInternetExplorerVersion", function(){
   var navigators = {
     nonIe: {

--- a/test/utils/xml/xml.spec.js
+++ b/test/utils/xml/xml.spec.js
@@ -4,10 +4,6 @@ describe("xml", function () {
   });
 
   describe("strToXMLDoc", function(){
-    it("must be a function", function(){
-      assert.isFunction(xml.strToXMLDoc);
-    });
-
     it("must throw an exception if it encounters a problem parsing the xml", function(){
       assert.throws(function () {
         xml.strToXMLDoc('');
@@ -42,11 +38,6 @@ describe("xml", function () {
   });
 
   describe("parseText", function () {
-
-    it("must be a function", function () {
-      assert.isFunction(xml.parseText);
-    });
-
     it("must return null if you pass an empty string or a string full of spaces", function () {
       assert.equal(xml.parseText(''), null);
       assert.equal(xml.parseText('   '), null);
@@ -223,20 +214,12 @@ describe("xml", function () {
   });
 
   describe("encode", function(){
-    it("must be a function", function(){
-      assert.isFunction(xml.encode);
-    });
-
     it("must encode &, \", ', < and >", function(){
       assert.equal(xml.encode("<br/> \"'"), '&lt;br/&gt; &quot;&apos;' );
     });
   });
 
   describe("decode", function(){
-    it("must be a function", function(){
-      assert.isFunction(xml.decode);
-    });
-
     it("must edcode a previously encoded xml", function(){
       assert.equal(xml.decode('&lt;br/&gt; &quot;&apos;'), "<br/> \"'");
     });


### PR DESCRIPTION
* Added the *adTagXML* option to the plugin to be able to request the VAST ad outside of the plugin
* Added the *adTagURL* option to the plugin to clarify the intent of the url option
* Deprecated the *url* option  in the plugin as the "adTagUrl" is a better name for it.
* Updated the README.md witht he new plugin options
* Updated Demo to use the new *adTagXML* option with the custom XML mode
* Removed unnecessary tests.
* jshinted specs
* Moved bower dependencies to devDependencies to avoid unnecessary downloads whenever somebody downloads the plugin as a dependency with bower.