### PR TITLE
'vast.contentEnded' -> 'vast.contentEnd'

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@
 ### 'vast.contentStart' event
   Fired whenever the video content starts playing
 
-### 'vast.contentEnded' event
+### 'vast.contentEnd' event
   Fired when the video content ends.
 
 ### 'vast.reset' event


### PR DESCRIPTION
Looks like a typo--the event is definitely `vast.contentEnd`.