### PR TITLE
fixing preinstall script - don't setup git hooks if git folder is not present

### DIFF
--- a/scripts/setup-hooks
+++ b/scripts/setup-hooks
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 #DON'T SETUP THE HOOKS IF YOU ARE IN CI
-if [ "$CONTINUOUS_INTEGRATION" != "true" ]; then
+if [ "$CONTINUOUS_INTEGRATION" != "true" ] && [ -d ".git" ]; then
   echo "Setting pre-commit hook"
   ln -f -s "$PWD/scripts/pre-commit" .git/hooks/pre-commit
 


### PR DESCRIPTION
fix #106 