### PR TITLE
'play' event race condition

### DIFF
--- a/src/ads/vast/client/VASTIntegrator.js
+++ b/src/ads/vast/client/VASTIntegrator.js
@@ -302,7 +302,6 @@ VASTIntegrator.prototype._playSelectedAd = function playSelectedAd(source, respo
 
   /**** local functions ******/
   function playAd() {
-    player.play();
     playerUtils.once(player, ['playing', 'vast.adsCancel'], function (evt) {
       if(evt.type === 'vast.adsCancel'){
         return;
@@ -317,6 +316,7 @@ VASTIntegrator.prototype._playSelectedAd = function playSelectedAd(source, respo
         //NOTE: if the ads get cancel we do nothing
       });
     });
+    player.play();
   }
 };
 


### PR DESCRIPTION
There is a race condition where 'play' is triggered by the player before the necessary event listeners are attached and registered. The outcome is that the ad's audio will play video remains black, possibly due to overlay), and the ad wait timeout is triggered causing the ad to cancel and the normal content to resume.

The fix is simple: move the call to `player.play()` AFTER the listener is attached.