### PR TITLE
FIX: Infinite `volumechange` loop

### DIFF
--- a/src/scripts/ads/vpaid/VPAIDIntegrator.js
+++ b/src/scripts/ads/vpaid/VPAIDIntegrator.js
@@ -338,15 +338,17 @@ VPAIDIntegrator.prototype._setupEvents = function (adUnit, vastResponse, next) {
     player.trigger('vpaid.AdVolumeChange');
     var lastVolume = player.volume();
     adUnit.getAdVolume(function (error, currentVolume) {
-      if (currentVolume === 0 && lastVolume > 0) {
-        tracker.trackMute();
-      }
+      if (lastVolume !== currentVolume) {
+        if (currentVolume === 0 && lastVolume > 0) {
+          tracker.trackMute();
+        }
 
-      if (currentVolume > 0 && lastVolume === 0) {
-        tracker.trackUnmute();
-      }
+        if (currentVolume > 0 && lastVolume === 0) {
+          tracker.trackUnmute();
+        }
 
-      player.volume(currentVolume);
+        player.volume(currentVolume);
+      }
     });
   });
 
@@ -466,11 +468,14 @@ VPAIDIntegrator.prototype._linkPlayerControls = function (adUnit, vastResponse, 
 
     function updatePlayerVolume() {
       player.trigger('vpaid.AdVolumeChange');
+      var lastVolume = player.volume();
       adUnit.getAdVolume(function (error, vol) {
         if (error) {
           logError(error);
         } else {
-          player.volume(vol);
+          if (lastVolume !== vol) {
+            player.volume(vol);
+          }
         }
       });
     }

--- a/test/ads/vpaid/VPAIDIntegrator.spec.js
+++ b/test/ads/vpaid/VPAIDIntegrator.spec.js
@@ -686,7 +686,6 @@ describe("VPAIDIntegrator", function () {
           this.clock.tick();
           sinon.assert.notCalled(tracker.trackMute);
           sinon.assert.notCalled(tracker.trackUnmute);
-          sinon.assert.calledWithExactly(player.volume, 0);
         });
 
         it("must tack unmute if the volume was 0 and changes to not cero", function(){


### PR DESCRIPTION
When used in conjunction with a Flash video and `video-js-swf`, if a VPAID ad triggers a volume change, this causes an infinite loop of constantly setting the volume on the player.

First, the VPAID event `AdVolumeChange` event gets fired which the plugin handles and calls `player.volume()` with the new value. The VideoJS code then sees that event `volumechange` and passes it down to the `video-js-swf` ActionScript code which sets the `volume` property in the SWF and ends its cycle by broadcasting the `volumechange` event to VideoJS's JavaScript. This plugin code then sees that event, passes it down to the ActionScrip, and the cycle goes on forever.

This change simply checks the `lastVolume` variable and if, in the callback, the `currentVolume` is no different, the plugin doesn't attempt to call `player.volume()`. The loop will go all the way down to `video-js-swf` and back to this plugin once, but it will stop there and not be infinite.