### PR TITLE
update deprecated init function to constructor

### DIFF
--- a/src/scripts/plugin/components/ads-label.js
+++ b/src/scripts/plugin/components/ads-label.js
@@ -9,7 +9,7 @@ element.innerHTML = 'Advertisement';
 var AdsLabelFactory = function(baseComponent) {
   return {
     /** @constructor */
-    init: function init(player, options) {
+    constructor: function init(player, options) {
       options.el = element;
       baseComponent.call(this, player, options);
 

--- a/src/scripts/plugin/components/black-poster.js
+++ b/src/scripts/plugin/components/black-poster.js
@@ -19,7 +19,7 @@ var element = document.createElement('div');
 var BlackPosterFactory = function(baseComponent) {
   return {
     /** @constructor */
-    init: function init(player, options) {
+    constructor: function init(player, options) {
       options.el = element;
       element.className = 'vjs-black-poster';
       baseComponent.call(this, player, options);


### PR DESCRIPTION
There is a warning in videojs-vast-vpaid plugin. "VIDEOJS: WARN: Constructor logic via init() is deprecated; please use constructor() instead." I update the code to remove this warning.