### PR TITLE
Midroll, postroll support

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,22 @@ verbosity of console logging;
 - 3 - error, warn, info, log
 - 4 - error, warn, info, log, debug
 
+#### preroll
+
+Flag to enable/disable whether a preroll is shown. 
+```Defaults to true```
+
+#### midrolls
+
+An array of start points for when to show midrolls.
+The midroll array will be validated for conformance. It checks that it is an array, and that each value in the array is a number as well as each value also being less than the duration of the current video.
+```Defaults to []```
+
+#### postroll
+Flag to enable/disable whether a postroll is shown. 
+```Defaults to false```
+
+
 
 ---
 

--- a/src/scripts/plugin/videojs.vast.vpaid.js
+++ b/src/scripts/plugin/videojs.vast.vpaid.js
@@ -103,7 +103,7 @@ module.exports = function VASTPlugin(options) {
 
   if (settings.preroll && utilities.isBool(settings.preroll)) {
     player.on('vast.firstPlay', function () {
-      tryToPlayRollAd('pre');
+      tryToPlayRollAd();
     });
   }
 
@@ -114,7 +114,7 @@ module.exports = function VASTPlugin(options) {
   if (settings.postroll && utilities.isBool(settings.postroll)) {
     player.on('vast.contentEnd', function () {
       if (player.currentTime() > player.duration() - 1) {
-        tryToPlayRollAd('post'); 
+        tryToPlayRollAd(); 
       }
     });
   }
@@ -133,7 +133,7 @@ module.exports = function VASTPlugin(options) {
 
       if (player.currentTime() < settings.midrolls[currentMidrollIndex] && 
           player.currentTime() > settings.midrolls[currentMidrollIndex]-lookAhead) {
-        tryToPlayRollAd('mid');
+        tryToPlayRollAd();
         midrollsPlayed++;
       }
     }

--- a/src/scripts/plugin/videojs.vast.vpaid.js
+++ b/src/scripts/plugin/videojs.vast.vpaid.js
@@ -256,8 +256,7 @@ module.exports = function VASTPlugin(options) {
 
   return player.vast;
 
-  function tryToPlayRollAd(rollType) {
-    console.log('tryToPlayRollAd ', rollType);
+  function tryToPlayRollAd() {
     // stop listening for timeupdate, we only do that for content
     player.off('timeupdate', timeupdateWatcher);
     // set flag

--- a/src/scripts/plugin/videojs.vast.vpaid.js
+++ b/src/scripts/plugin/videojs.vast.vpaid.js
@@ -101,7 +101,7 @@ module.exports = function VASTPlugin(options) {
     });
   }
 
-  if (settings.preroll) {
+  if (settings.preroll && utilities.isBool(settings.preroll)) {
     player.on('vast.firstPlay', function () {
       tryToPlayRollAd('pre');
     });
@@ -111,7 +111,7 @@ module.exports = function VASTPlugin(options) {
     adIsPlaying = false;
   });
 
-  if (settings.postroll) {
+  if (settings.postroll && utilities.isBool(settings.postroll)) {
     player.on('vast.contentEnd', function () {
       if (player.currentTime() > player.duration() - 1) {
         tryToPlayRollAd('post'); 

--- a/src/scripts/plugin/videojs.vast.vpaid.js
+++ b/src/scripts/plugin/videojs.vast.vpaid.js
@@ -65,8 +65,7 @@ module.exports = function VASTPlugin(options) {
 
   var settings = utilities.extend({}, defaultOpts, options || {});
 
-
-  var totalMidrolls = settings.midrolls.length;
+  var totalMidrolls = utilities.isArray(settings.midrolls) ? settings.midrolls.length : 0;
   var midrollsPlayed = -1;
   var adIsPlaying = false;
 
@@ -119,8 +118,30 @@ module.exports = function VASTPlugin(options) {
     });
   }
 
+  function validateMidrolls(midrolls) {
+    
+    // it should be an array
+    if (!utilities.isArray(midrolls)) {
+      return false;
+    }
+
+    // the array should use numbers as values
+    for (var i=0,l=midrolls.length; i<l; i++) {
+      if (!utilities.isNumber(midrolls[i])) {
+        return false;
+      }
+
+      if (midrolls[i] >= player.duration()) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+
   function timeupdateWatcher() {
-    if (settings.midrolls && settings.midrolls.length > 0) {  
+    if (utilities.isArray(settings.midrolls) && settings.midrolls.length > 0) {  
       var currentMidrollIndex;
 
       if (midrollsPlayed < totalMidrolls) {
@@ -144,7 +165,7 @@ module.exports = function VASTPlugin(options) {
   });
 
   player.on('vast.contentStart', function () {
-    if (player.currentTime() < player.duration()) {
+    if (player.currentTime() < player.duration() && validateMidrolls(settings.midrolls)) {
       player.on('timeupdate', timeupdateWatcher);
     }
   });

--- a/src/scripts/utils/playerUtils.js
+++ b/src/scripts/utils/playerUtils.js
@@ -99,7 +99,7 @@ playerUtils.restorePlayerSnapshot = function restorePlayerSnapshot(player, snaps
 
   /**
    * Sometimes firefox does not trigger the 'canplay' evt.
-   * This code ensure that it always gets triggered triggered.
+   * This code ensures that it always gets triggered.
    */
   function ensureCanplayEvtGetsFired() {
     var timeoutId = setTimeout(function() {

--- a/src/scripts/utils/utilityFunctions.js
+++ b/src/scripts/utils/utilityFunctions.js
@@ -14,6 +14,10 @@ function isNull(o) {
   return o === null;
 }
 
+function isBool(bool){
+  return typeof bool === 'boolean';
+}
+
 function isDefined(o){
   return o !== undefined;
 }
@@ -291,6 +295,7 @@ var utilities = {
   _UA: navigator.userAgent,
   noop: noop,
   isNull: isNull,
+  isBool: isBool,
   isDefined: isDefined,
   isUndefined: isUndefined,
   isObject: isObject,

--- a/src/scripts/utils/utilityFunctions.js
+++ b/src/scripts/utils/utilityFunctions.js
@@ -125,9 +125,9 @@ function extend (obj) {
     arg = arguments[i];
     for (k in arg) {
       if (arg.hasOwnProperty(k)) {
-        if(isObject(obj[k]) && !isNull(obj[k]) && isObject(arg[k])){
+        if(isObject(obj[k]) && !isNull(obj[k]) && isObject(arg[k]) && !isArray(arg[k])){
           obj[k] = extend({}, obj[k], arg[k]);
-        }else {
+        } else {
           obj[k] = arg[k];
         }
       }

--- a/test/plugin/videojs.vast.spec.js
+++ b/test/plugin/videojs.vast.spec.js
@@ -469,7 +469,7 @@ describe("videojs.vast plugin", function () {
     });
   });
 
-  describe("playPrerollAd", function () {
+  describe("playRollAd", function () {
     var getVASTResponse, callback, old_UA;
 
     beforeEach(function () {
@@ -825,6 +825,7 @@ describe("videojs.vast plugin", function () {
       player.trigger('vast.adStart');
       assert.equal(player.vast.adUnit.type, 'VAST');
     });
+
   });
 
   describe("on iPhone", function(){

--- a/test/plugin/videojs.vast.spec.js
+++ b/test/plugin/videojs.vast.spec.js
@@ -117,6 +117,47 @@ describe("videojs.vast plugin", function () {
     assertError(spy, 'on VideoJS VAST plugin, the passed adTagXML option does not contain a function');
   });
 
+  it("must not try to play a preroll ad if the passed preroll is false", function () {
+    var player = videojs(document.createElement('video'), {});
+    var tryToPlayRollSpy = sinon.spy();
+
+    player.on('vast.firstPlay', tryToPlayRollSpy);
+    player.vastClient({preroll: false});
+
+    sinon.assert.notCalled(tryToPlayRollSpy);
+  });
+
+  it("must not try to play a postroll ad if the passed postroll is false", function () {
+    var player = videojs(document.createElement('video'), {});
+    var tryToPlayRollSpy = sinon.spy();
+
+    player.on('vast.contentEnd', tryToPlayRollSpy);
+    player.vastClient({postroll: false});
+
+    sinon.assert.notCalled(tryToPlayRollSpy);
+  });
+
+  it("must not try to play a postroll ad unless the player curenttime is within 1 second of completing", function () {
+    var player = videojs(document.createElement('video'), {});
+    var tryToPlayRollSpy = sinon.spy();
+
+    var playerAPI = {
+      currentTime: function () {
+        return 10;
+      },
+      duration: function () {
+        return 1;
+      }
+    };
+
+    player.on('vast.contentEnd', tryToPlayRollSpy);
+    player.vastClient({postroll: false});
+
+    if (playerAPI.currentTime() < playerAPI.duration() - 1) {
+      sinon.assert.notCalled(tryToPlayRollSpy);
+    }
+  });
+
   it("must cancel the ads on 'vast.reset' evt", function(){
     var spy = sinon.spy();
     var player = videojs(document.createElement('video'), {});


### PR DESCRIPTION
This PR is almost certainly not ready for a merge into master, but feedback would be welcome.

* adds support for midrolls and postrolls (https://github.com/MailOnline/videojs-vast-vpaid/issues/37)
* midrolls are defined by passing an array of timestarts to the vast config
* postroll is a similar, but a bool value.
* by default, both are set to values that will replicate the current behaviour (no midrolls or postroll)