### PR TITLE
Prevent async.waterfall multiple next/callback execution

### DIFF
--- a/src/scripts/utils/async.js
+++ b/src/scripts/utils/async.js
@@ -26,7 +26,7 @@ async.iterator = function (tasks) {
 
 
 async.waterfall = function (tasks, callback) {
-  callback = callback || function () { };
+  callback = utilities.once(callback || utilities.noop);
   if (!utilities.isArray(tasks)) {
     var err = new Error('First argument to waterfall must be an array of functions');
     return callback(err);
@@ -38,14 +38,13 @@ async.waterfall = function (tasks, callback) {
     return function (err) {
       if (err) {
         callback.apply(null, arguments);
-        callback = function () {
-        };
+        callback = utilities.noop;
       }
       else {
         var args = Array.prototype.slice.call(arguments, 1);
         var next = iterator.next();
         if (next) {
-          args.push(wrapIterator(next));
+          args.push(utilities.once(wrapIterator(next)));
         }
         else {
           args.push(callback);

--- a/src/scripts/utils/utilityFunctions.js
+++ b/src/scripts/utils/utilityFunctions.js
@@ -287,6 +287,15 @@ function isAndroid() {
   return /Android/.test(utilities._UA);
 }
 
+function once(fn) {
+  return function () {
+    if (fn === null) return;
+    var callFn = fn;
+    fn = null;
+    callFn.apply(this, arguments);
+  };
+}
+
 var utilities = {
   _UA: navigator.userAgent,
   noop: noop,
@@ -321,7 +330,8 @@ var utilities = {
   isIDevice: isIDevice,
   isMobile: isMobile,
   isIPhone: isIPhone,
-  isAndroid: isAndroid
+  isAndroid: isAndroid,
+  once: once
 };
 
 module.exports = utilities;

--- a/test/utils/async.spec.js
+++ b/test/utils/async.spec.js
@@ -88,10 +88,12 @@ describe("async", function () {
 
         function startCounter(next) {
           next(null, 0);
+          next(null, 0); // Test multiple callbacks
         }
 
         function increaseCounter(counter, next) {
           next(null, counter + 1);
+          next(null, counter + 1); // Test multiple callbacks
         }
 
         async.waterfall([


### PR DESCRIPTION
You use old version of async.waterfall that does not guarantee single next/callback execution with multiple "next(null)" calling.