### PR TITLE
if version is already a number, split fails

### DIFF
--- a/src/scripts/ads/vpaid/VPAIDIntegrator.js
+++ b/src/scripts/ads/vpaid/VPAIDIntegrator.js
@@ -225,6 +225,9 @@ VPAIDIntegrator.prototype._handshake = function handshake(adUnit, vastResponse, 
   }
 
   function major(version) {
+    if (utilities.isNumber(version)) {
+      return Math.floor(version);
+    }
     var parts = version.split('.');
     return parseInt(parts[0], 10);
   }


### PR DESCRIPTION
fix a "split is not a function" because version (could) already be a number.